### PR TITLE
Optimize # of API requests to prevent throttling

### DIFF
--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -86,12 +86,16 @@ export class WorkbenchJupyterServerProvider
    * This gets invoked every time the value (what the user has typed into the
    * quick pick) changes. But we just return a static list which will be
    * filtered down by the quick pick automatically.
+   *
+   * It also sets a flag to refresh the server list on the next call to
+   * `getWorkbenchServers`. This is needed to ensure that the server list is
+   * refreshed when the user interacts with the command palette.
    */
   provideCommands(
     _value: string | undefined,
     _token: CancellationToken,
   ): JupyterServerCommand[] {
-    this.instanceManager.setShouldRefresh(true);
+    this.instanceManager.setShouldRefresh();
     return [WORKBENCH_COMMAND];
   }
 

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -91,6 +91,7 @@ export class WorkbenchJupyterServerProvider
     _value: string | undefined,
     _token: CancellationToken,
   ): JupyterServerCommand[] {
+    this.instanceManager.setShouldRefresh(true);
     return [WORKBENCH_COMMAND];
   }
 

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -89,7 +89,8 @@ export class WorkbenchJupyterServerProvider
    *
    * It also sets a flag to refresh the server list on the next call to
    * `getWorkbenchServers`. This is needed to ensure that the server list is
-   * refreshed when the user interacts with the command palette.
+   * refreshed when the user interacts with the command palette. That is also
+   * why the method needs to stay synchronous.
    */
   provideCommands(
     _value: string | undefined,

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -180,6 +180,7 @@ describe("WorkbenchJupyterServerProvider", () => {
       );
       expect(commands).to.have.lengthOf(1);
       expect(commands[0]).to.deep.equal(WORKBENCH_COMMAND);
+      sinon.assert.calledWith(instanceManagerStub.setShouldRefresh, true);
     });
   });
 

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -180,7 +180,7 @@ describe("WorkbenchJupyterServerProvider", () => {
       );
       expect(commands).to.have.lengthOf(1);
       expect(commands[0]).to.deep.equal(WORKBENCH_COMMAND);
-      sinon.assert.calledWith(instanceManagerStub.setShouldRefresh, true);
+      sinon.assert.calledWith(instanceManagerStub.setShouldRefresh);
     });
   });
 

--- a/src/jupyter/workbench-instance-manager.ts
+++ b/src/jupyter/workbench-instance-manager.ts
@@ -49,12 +49,17 @@ export class WorkbenchInstanceManager {
   private cachedServers: WorkbenchJupyterServer[] = [];
 
   /**
-   * Sets the flag indicating whether the server list should be refreshed.
+   * Sets the flag indicating whether the server list should be refreshed
+   * from the API on the next call to `getWorkbenchServers`.
    *
-   * @param shouldRefresh - True to mark for refresh, false otherwise.
+   * The flag is needed to prevent sending API calls to the Notebooks API
+   * every time the Jupyter extension calls `provideJupyterServers`, which
+   * happens even during cell execution. We only want to refresh the server
+   * list when the user explicitly requests it by interacting with the
+   * command palette.
    */
-  setShouldRefresh(shouldRefresh: boolean) {
-    this.shouldRefresh = shouldRefresh;
+  setShouldRefresh() {
+    this.shouldRefresh = true;
   }
 
   /**
@@ -74,14 +79,10 @@ export class WorkbenchInstanceManager {
   /**
    * Sets the current GCP project ID.
    *
-   * This invalidates the cached server list, causing it to be refreshed from
-   * the API on the next call to `getWorkbenchServers`.
-   *
    * @param projectId - The ID of the GCP project.
    */
   setProjectId(projectId: string) {
     this.projectId = projectId;
-    this.shouldRefresh = true;
   }
 
   /**
@@ -118,11 +119,25 @@ export class WorkbenchInstanceManager {
       return this.cachedServers;
     }
 
-    const instances = await this.notebooksClient.listInstances(projectId);
+    const instances = await this.vs.window.withProgress(
+      {
+        location: this.vs.ProgressLocation.Notification,
+        title: "Fetching Workbench instances...",
+        cancellable: false,
+      },
+      () => this.notebooksClient.listInstances(projectId),
+    );
     this.cachedServers = instances.map((instance) =>
       this.createWorkbenchJupyterServer(instance, projectId),
     );
     this.shouldRefresh = false;
+
+    if (this.cachedServers.length === 0) {
+      this.vs.window.showInformationMessage(
+        `No Workbench instances found in project: ${projectId}.`,
+      );
+    }
+
     return this.cachedServers;
   }
 

--- a/src/jupyter/workbench-instance-manager.ts
+++ b/src/jupyter/workbench-instance-manager.ts
@@ -45,6 +45,17 @@ export interface WorkbenchJupyterServer extends JupyterServer {
  */
 export class WorkbenchInstanceManager {
   private projectId?: string;
+  private shouldRefresh = false;
+  private cachedServers: WorkbenchJupyterServer[] = [];
+
+  /**
+   * Sets the flag indicating whether the server list should be refreshed.
+   *
+   * @param shouldRefresh - True to mark for refresh, false otherwise.
+   */
+  setShouldRefresh(shouldRefresh: boolean) {
+    this.shouldRefresh = shouldRefresh;
+  }
 
   /**
    * Creates a new instance of WorkbenchInstanceManager.
@@ -63,10 +74,14 @@ export class WorkbenchInstanceManager {
   /**
    * Sets the current GCP project ID.
    *
+   * This invalidates the cached server list, causing it to be refreshed from
+   * the API on the next call to `getWorkbenchServers`.
+   *
    * @param projectId - The ID of the GCP project.
    */
   setProjectId(projectId: string) {
     this.projectId = projectId;
+    this.shouldRefresh = true;
   }
 
   /**
@@ -99,10 +114,16 @@ export class WorkbenchInstanceManager {
       return [];
     }
 
+    if (!this.shouldRefresh) {
+      return this.cachedServers;
+    }
+
     const instances = await this.notebooksClient.listInstances(projectId);
-    return instances.map((instance) =>
+    this.cachedServers = instances.map((instance) =>
       this.createWorkbenchJupyterServer(instance, projectId),
     );
+    this.shouldRefresh = false;
+    return this.cachedServers;
   }
 
   /**

--- a/src/jupyter/workbench-instance-manager.unit.test.ts
+++ b/src/jupyter/workbench-instance-manager.unit.test.ts
@@ -57,6 +57,17 @@ describe("WorkbenchInstanceManager", () => {
       notebooksClientStub,
       getAccessTokenStub,
     );
+
+    vsCodeStub.window.withProgress.callsFake(async (_options, task) => {
+      return task(
+        {
+          report: () => {
+            /* empty */
+          },
+        },
+        new vsCodeStub.CancellationTokenSource().token,
+      );
+    });
   });
 
   afterEach(() => {

--- a/src/jupyter/workbench-instance-manager.unit.test.ts
+++ b/src/jupyter/workbench-instance-manager.unit.test.ts
@@ -110,6 +110,49 @@ describe("WorkbenchInstanceManager", () => {
       expect(server.name).to.equal("UNKNOWN_NAME");
       expect(server.proxyUri).to.equal("");
     });
+
+    it("should cache servers after initial fetch", async () => {
+      notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
+      manager.setProjectId(PROJECT_ID);
+
+      // First call fetches from API
+      await manager.getWorkbenchServers();
+      sinon.assert.calledOnce(notebooksClientStub.listInstances);
+
+      // Second call should return cached
+      const servers = await manager.getWorkbenchServers();
+      sinon.assert.calledOnce(notebooksClientStub.listInstances); // Still called once
+      expect(servers).to.have.lengthOf(1);
+    });
+
+    it("should refresh cache when setShouldRefresh is called", async () => {
+      notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
+      manager.setProjectId(PROJECT_ID);
+
+      // First call
+      await manager.getWorkbenchServers();
+
+      // Force refresh
+      manager.setShouldRefresh(true);
+
+      // Second call should fetch again
+      await manager.getWorkbenchServers();
+      sinon.assert.calledTwice(notebooksClientStub.listInstances);
+    });
+
+    it("should refresh cache when project ID changes", async () => {
+      notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
+      manager.setProjectId(PROJECT_ID);
+      await manager.getWorkbenchServers();
+
+      // Change project ID
+      const newProjectId = "new-project";
+      manager.setProjectId(newProjectId);
+
+      await manager.getWorkbenchServers();
+      sinon.assert.calledTwice(notebooksClientStub.listInstances);
+      sinon.assert.calledWith(notebooksClientStub.listInstances, newProjectId);
+    });
   });
 
   describe("refreshConnection", () => {

--- a/src/jupyter/workbench-instance-manager.unit.test.ts
+++ b/src/jupyter/workbench-instance-manager.unit.test.ts
@@ -57,17 +57,6 @@ describe("WorkbenchInstanceManager", () => {
       notebooksClientStub,
       getAccessTokenStub,
     );
-
-    vsCodeStub.window.withProgress.callsFake(async (_options, task) => {
-      return task(
-        {
-          report: () => {
-            /* empty */
-          },
-        },
-        new vsCodeStub.CancellationTokenSource().token,
-      );
-    });
   });
 
   afterEach(() => {

--- a/src/jupyter/workbench-instance-manager.unit.test.ts
+++ b/src/jupyter/workbench-instance-manager.unit.test.ts
@@ -57,6 +57,17 @@ describe("WorkbenchInstanceManager", () => {
       notebooksClientStub,
       getAccessTokenStub,
     );
+
+    vsCodeStub.window.withProgress.callsFake(async (_options, task) => {
+      return task(
+        {
+          report: () => {
+            /* empty */
+          },
+        },
+        new vsCodeStub.CancellationTokenSource().token,
+      );
+    });
   });
 
   afterEach(() => {
@@ -72,6 +83,7 @@ describe("WorkbenchInstanceManager", () => {
     it("should fetch and convert servers correctly when projectId is set", async () => {
       notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
       manager.setProjectId(PROJECT_ID);
+      manager.setShouldRefresh();
 
       const servers = await manager.getWorkbenchServers();
 
@@ -83,15 +95,19 @@ describe("WorkbenchInstanceManager", () => {
       expect(server.proxyUri).to.equal(PROXY_URI);
       expect(server.label).to.equal(`test-instance (test-project)`);
       sinon.assert.calledWith(notebooksClientStub.listInstances, PROJECT_ID);
+      sinon.assert.calledOnce(vsCodeStub.window.withProgress);
+      sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
     });
 
     it("should handle empty instance list", async () => {
       notebooksClientStub.listInstances.resolves([]);
       manager.setProjectId(PROJECT_ID);
+      manager.setShouldRefresh();
 
       const servers = await manager.getWorkbenchServers();
 
       expect(servers).to.have.lengthOf(0);
+      sinon.assert.calledOnce(vsCodeStub.window.showInformationMessage);
     });
 
     it("should handle instances with missing fields (defaults)", async () => {
@@ -101,6 +117,7 @@ describe("WorkbenchInstanceManager", () => {
         },
       ]);
       manager.setProjectId(PROJECT_ID);
+      manager.setShouldRefresh();
 
       const servers = await manager.getWorkbenchServers();
 
@@ -114,6 +131,7 @@ describe("WorkbenchInstanceManager", () => {
     it("should cache servers after initial fetch", async () => {
       notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
       manager.setProjectId(PROJECT_ID);
+      manager.setShouldRefresh();
 
       // First call fetches from API
       await manager.getWorkbenchServers();
@@ -128,30 +146,17 @@ describe("WorkbenchInstanceManager", () => {
     it("should refresh cache when setShouldRefresh is called", async () => {
       notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
       manager.setProjectId(PROJECT_ID);
+      manager.setShouldRefresh();
 
       // First call
       await manager.getWorkbenchServers();
 
       // Force refresh
-      manager.setShouldRefresh(true);
+      manager.setShouldRefresh();
 
       // Second call should fetch again
       await manager.getWorkbenchServers();
       sinon.assert.calledTwice(notebooksClientStub.listInstances);
-    });
-
-    it("should refresh cache when project ID changes", async () => {
-      notebooksClientStub.listInstances.resolves([MOCK_INSTANCE]);
-      manager.setProjectId(PROJECT_ID);
-      await manager.getWorkbenchServers();
-
-      // Change project ID
-      const newProjectId = "new-project";
-      manager.setProjectId(newProjectId);
-
-      await manager.getWorkbenchServers();
-      sinon.assert.calledTwice(notebooksClientStub.listInstances);
-      sinon.assert.calledWith(notebooksClientStub.listInstances, newProjectId);
     });
   });
 

--- a/src/workbench/commands.ts
+++ b/src/workbench/commands.ts
@@ -66,6 +66,7 @@ export async function selectProjectCommand(
     await MultiStepInput.run(vs, pickProject);
     if (selectedProject?.detail) {
       instanceManager.setProjectId(selectedProject.detail);
+      instanceManager.setShouldRefresh();
     }
   } catch (error: unknown) {
     // If the user cancelled, MultiStepInput throws InputFlowAction.cancel

--- a/src/workbench/commands.unit.test.ts
+++ b/src/workbench/commands.unit.test.ts
@@ -102,6 +102,7 @@ describe("selectProjectCommand", () => {
 
     sinon.assert.calledOnce(multiStepRunStub);
     sinon.assert.calledWith(instanceManagerStub.setProjectId, "p-id");
+    sinon.assert.calledOnce(instanceManagerStub.setShouldRefresh);
     sinon.assert.notCalled(executeCommandStub);
   });
 });


### PR DESCRIPTION
Prevent sending API requests every time `provideJupyterServers` is called to avoid API throttling.

if user navigates server selection menu - we should always serve them fresh servers by making the API call. Otherwise, we serve cached instances, e.g. during cell execution because we do not expect them to change. In case the instance will be stopped while the user is executing cells there will be a disconnect anyway and they will need to select a new server from the list, which will come from the API request.