### PR TITLE
Fix invalid grant when activating an extension

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -120,7 +120,18 @@ export class GoogleAuthProvider
       token_type: 'Bearer',
       scope: session.scopes.join(' '),
     });
-    await this.oAuth2Client.refreshAccessToken();
+    try {
+      await this.oAuth2Client.refreshAccessToken();
+    } catch (err: unknown) {
+      console.warn(
+        `Failed to refresh token during initialization: ${String(err)}`,
+      );
+      // The refresh token is likely invalid or revoked.
+      // Clear the session so the user can sign in again.
+      await this.storage.removeSession(session.id);
+      this.isInitialized = true;
+      return;
+    }
     const accessToken = this.oAuth2Client.credentials.access_token;
     if (!accessToken) {
       throw new Error('Failed to refresh Google OAuth token.');

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -219,6 +219,20 @@ describe('GoogleAuthProvider', () => {
             changed: [DEFAULT_AUTH_SESSION],
           });
         });
+        it('handles "Invalid grant" error by clearing session', async () => {
+          sinon
+            .stub(oauth2Client, 'refreshAccessToken')
+            .rejects(new Error('Invalid grant'));
+
+          await expect(authProvider.initialize()).to.eventually.be.fulfilled;
+
+          sinon.assert.calledOnceWithExactly(
+            storageStub.removeSession,
+            DEFAULT_REFRESH_SESSION.id,
+          );
+          const sessions = await authProvider.getSessions(undefined, {});
+          expect(sessions).to.deep.equal([]);
+        });
       });
     });
   });


### PR DESCRIPTION
#### Problem
If your refresh token gets revoked or invalid for whatever reason than you might end up in a state when the extension cannot activate itself resulting in `Activating extension failed: invalid_grant.` 

#### Solution
To recover from that state you need to clean the session which will eventually force the user to authenticate again.