### PR TITLE
Handle sign-out gracefully

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -24,6 +24,19 @@ const PROVIDER_LABEL = 'Google Cloud Platform';
 const REFRESH_MARGIN_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
+ * An {@link vscode.Event} which fires when an authentication session is added,
+ * removed, or changed.
+ */
+export interface AuthChangeEvent
+  extends vscode.AuthenticationProviderAuthenticationSessionsChangeEvent {
+  /**
+   * True when there is a valid {@link vscode.AuthenticationSession} for the
+   * {@link vscode.AuthenticationProvider}.
+   */
+  hasValidSession: boolean;
+}
+
+/**
  * Provides authentication using Google OAuth2.
  *
  * Registers itself with the VS Code authentication API and emits events when
@@ -35,10 +48,10 @@ const REFRESH_MARGIN_MS = 5 * 60 * 1000; // 5 minutes
 export class GoogleAuthProvider
   implements vscode.AuthenticationProvider, vscode.Disposable
 {
-  readonly onDidChangeSessions: vscode.Event<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>;
+  readonly onDidChangeSessions: vscode.Event<AuthChangeEvent>;
   private isInitialized = false;
   private readonly authProvider: vscode.Disposable;
-  private readonly emitter: vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>;
+  private readonly emitter: vscode.EventEmitter<AuthChangeEvent>;
   private session?: Readonly<AuthenticationSession>;
   private readonly disposeController = new AbortController();
   private readonly disposeSignal: AbortSignal = this.disposeController.signal;
@@ -60,8 +73,7 @@ export class GoogleAuthProvider
     private readonly oAuth2Client: OAuth2Client,
     private readonly login: (scopes: string[]) => Promise<Credentials>,
   ) {
-    this.emitter =
-      new vs.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+    this.emitter = new vs.EventEmitter<AuthChangeEvent>();
     this.onDidChangeSessions = this.emitter.event;
 
     this.authProvider = this.vs.authentication.registerAuthenticationProvider(
@@ -147,6 +159,7 @@ export class GoogleAuthProvider
       added: [],
       removed: [],
       changed: [this.session],
+      hasValidSession: true,
     });
   }
 
@@ -245,12 +258,14 @@ export class GoogleAuthProvider
           added: [],
           removed: [],
           changed: [this.session],
+          hasValidSession: true,
         });
       } else {
         this.emitter.fire({
           added: [this.session],
           removed: [],
           changed: [],
+          hasValidSession: true,
         });
       }
       this.vs.window.showInformationMessage(
@@ -291,6 +306,7 @@ export class GoogleAuthProvider
       added: [],
       removed: [removedSession],
       changed: [],
+      hasValidSession: false,
     });
   }
 

--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -302,6 +302,10 @@ export class GoogleAuthProvider
     }
     await this.storage.removeSession(sessionId);
 
+    this.vs.window.showInformationMessage(
+      'Signed out of Google Cloud Platform!',
+    );
+
     this.emitter.fire({
       added: [],
       removed: [removedSession],

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -17,7 +17,11 @@ import {
   AUTHORIZATION_HEADER,
   CONTENT_TYPE_JSON_HEADER,
 } from '../workbench/headers';
-import { GoogleAuthProvider, REQUIRED_SCOPES, AuthChangeEvent } from './auth-provider';
+import {
+  GoogleAuthProvider,
+  REQUIRED_SCOPES,
+  AuthChangeEvent,
+} from './auth-provider';
 import { Credentials } from './login';
 import { AuthStorage, RefreshableAuthenticationSession } from './storage';
 

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -17,7 +17,7 @@ import {
   AUTHORIZATION_HEADER,
   CONTENT_TYPE_JSON_HEADER,
 } from '../workbench/headers';
-import { GoogleAuthProvider, REQUIRED_SCOPES } from './auth-provider';
+import { GoogleAuthProvider, REQUIRED_SCOPES, AuthChangeEvent } from './auth-provider';
 import { Credentials } from './login';
 import { AuthStorage, RefreshableAuthenticationSession } from './storage';
 
@@ -79,9 +79,7 @@ describe('GoogleAuthProvider', () => {
    * compromise, but it seems like the best middle ground.
    */
   let oauth2Client: OAuth2Client;
-  let onDidChangeSessionsStub: sinon.SinonStub<
-    [vscode.AuthenticationProviderAuthenticationSessionsChangeEvent]
-  >;
+  let onDidChangeSessionsStub: sinon.SinonStub<[AuthChangeEvent]>;
   let authProvider: GoogleAuthProvider;
 
   beforeEach(() => {
@@ -217,6 +215,7 @@ describe('GoogleAuthProvider', () => {
             added: [],
             removed: [],
             changed: [DEFAULT_AUTH_SESSION],
+            hasValidSession: true,
           });
         });
         it('handles "Invalid grant" error by clearing session', async () => {
@@ -551,6 +550,7 @@ describe('GoogleAuthProvider', () => {
           added: [newSession],
           removed: [],
           changed: [],
+          hasValidSession: true,
         });
       });
 
@@ -567,6 +567,7 @@ describe('GoogleAuthProvider', () => {
           added: [],
           removed: [],
           changed: [session],
+          hasValidSession: true,
         });
       });
     });
@@ -648,6 +649,7 @@ describe('GoogleAuthProvider', () => {
           added: [],
           removed: [session[0]],
           changed: [],
+          hasValidSession: false,
         });
       });
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,13 +35,12 @@ export async function activate(context: vscode.ExtensionContext) {
     authClient,
     (scopes: string[]) => login(vscode, authFlows, authClient, scopes),
   );
-  await authProvider.initialize();
-
   const notebooksClient = new NotebooksClient(authClient);
   const projectsClient = new ProjectsClient(authClient);
 
   const workbenchServerProvider = new WorkbenchJupyterServerProvider(
     vscode,
+    authProvider.onDidChangeSessions,
     projectsClient,
     new WorkbenchInstanceManager(vscode, notebooksClient, () =>
       GoogleAuthProvider.getOrCreateSession(vscode).then(
@@ -50,6 +49,8 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
     jupyter,
   );
+
+  await authProvider.initialize();
 
   context.subscriptions.push(
     disposeAll(authFlows),

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -14,7 +14,7 @@ import {
 } from '@vscode/jupyter-extension';
 import type { CancellationToken } from 'vscode';
 import vscode from 'vscode';
-import { GoogleAuthProvider } from '../auth/auth-provider';
+import { GoogleAuthProvider, AuthChangeEvent } from '../auth/auth-provider';
 import { selectProjectCommand } from '../workbench/commands';
 import { WORKBENCH_COMMAND } from '../workbench/constants';
 import { ProjectsClient } from '../workbench/projects-client';
@@ -39,9 +39,12 @@ export class WorkbenchJupyterServerProvider
 
   private readonly serverCollection: JupyterServerCollection;
   private readonly serverChangeEmitter: vscode.EventEmitter<void>;
+  private isAuthorized = false;
+  private readonly authListener: vscode.Disposable;
 
   constructor(
     private readonly vs: typeof vscode,
+    authEvent: vscode.Event<AuthChangeEvent>,
     private readonly projectsClient: ProjectsClient,
     private readonly instanceManager: WorkbenchInstanceManager,
     jupyter: Jupyter,
@@ -55,9 +58,12 @@ export class WorkbenchJupyterServerProvider
       this,
     );
     this.serverCollection.commandProvider = this;
+
+    this.authListener = authEvent(this.handleAuthChange.bind(this));
   }
 
   dispose() {
+    this.authListener.dispose();
     this.serverCollection.dispose();
   }
 
@@ -67,6 +73,9 @@ export class WorkbenchJupyterServerProvider
   async provideJupyterServers(
     _token: CancellationToken,
   ): Promise<JupyterServer[]> {
+    if (!this.isAuthorized) {
+      return [];
+    }
     return await this.instanceManager.getWorkbenchServers();
   }
 
@@ -77,6 +86,9 @@ export class WorkbenchJupyterServerProvider
     workbenchServer: WorkbenchJupyterServer,
     _token: CancellationToken,
   ): Promise<WorkbenchJupyterServer> {
+    if (!this.isAuthorized) {
+      throw new Error('Not authorized');
+    }
     return await this.instanceManager.refreshConnection(workbenchServer);
   }
 
@@ -125,5 +137,13 @@ export class WorkbenchJupyterServerProvider
       console.error(err);
       throw err;
     }
+  }
+
+  private handleAuthChange(e: AuthChangeEvent): void {
+    if (this.isAuthorized === e.hasValidSession) {
+      return;
+    }
+    this.isAuthorized = e.hasValidSession;
+    this.serverChangeEmitter.fire();
   }
 }

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -87,9 +87,9 @@ export class WorkbenchJupyterServerProvider
     _token: CancellationToken,
   ): Promise<WorkbenchJupyterServer> {
     if (!this.isAuthorized) {
-      const message = 'Unauthorized: unable to resolve Jupyter server'
+      const message = 'Unauthorized: unable to resolve Jupyter server';
       // Logging the error because Jupyter extension swallows it
-      console.error(message) 
+      console.error(message);
 
       throw new Error(message);
     }

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -87,7 +87,11 @@ export class WorkbenchJupyterServerProvider
     _token: CancellationToken,
   ): Promise<WorkbenchJupyterServer> {
     if (!this.isAuthorized) {
-      throw new Error('Not authorized');
+      const message = 'Unauthorized: unable to resolve Jupyter server'
+      // Logging the error because Jupyter extension swallows it
+      console.error(message) 
+
+      throw new Error(message);
     }
     return await this.instanceManager.refreshConnection(workbenchServer);
   }
@@ -144,6 +148,7 @@ export class WorkbenchJupyterServerProvider
       return;
     }
     this.isAuthorized = e.hasValidSession;
+    this.instanceManager.setProjectId(undefined);
     this.serverChangeEmitter.fire();
   }
 }

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -13,7 +13,8 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { SinonStubbedInstance } from 'sinon';
 import vscode from 'vscode';
-import { GoogleAuthProvider } from '../auth/auth-provider';
+import { GoogleAuthProvider, AuthChangeEvent } from '../auth/auth-provider';
+import { TestEventEmitter } from '../test/helpers/events';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { WORKBENCH_COMMAND } from '../workbench/constants';
 import { ProjectsClient } from '../workbench/projects-client';
@@ -35,6 +36,7 @@ describe('WorkbenchJupyterServerProvider', () => {
   let projectsClientStub: SinonStubbedInstance<ProjectsClient>;
   let instanceManagerStub: SinonStubbedInstance<WorkbenchInstanceManager>;
   let serverProvider: WorkbenchJupyterServerProvider;
+  let authEventEmitter: TestEventEmitter<AuthChangeEvent>;
 
   const MOCK_SERVER: WorkbenchJupyterServer = {
     id: 'server-1',
@@ -56,6 +58,7 @@ describe('WorkbenchJupyterServerProvider', () => {
   beforeEach(() => {
     vsCodeStub = newVsCodeStub();
     cancellationToken = new vsCodeStub.CancellationTokenSource().token;
+    authEventEmitter = new TestEventEmitter<AuthChangeEvent>();
     serverCollectionDisposeStub = sinon.stub();
     jupyterStub = {
       createJupyterServerCollection: sinon.stub(),
@@ -81,12 +84,28 @@ describe('WorkbenchJupyterServerProvider', () => {
     projectsClientStub.getProjects.resolves([]);
     instanceManagerStub = sinon.createStubInstance(WorkbenchInstanceManager);
 
+    vsCodeStub.authentication.getSession = sinon.stub().resolves({
+      id: 'mock-session-id',
+      accessToken: 'mock-access-token',
+      account: { id: 'mock-account-id', label: 'Mock Account' },
+      scopes: [],
+    });
+
     serverProvider = new WorkbenchJupyterServerProvider(
       vsCodeStub.asVsCode(),
+      authEventEmitter.event,
       projectsClientStub,
       instanceManagerStub,
       jupyterStub as unknown as Jupyter,
     );
+
+    // Simulate login
+    authEventEmitter.fire({
+      added: [],
+      removed: [],
+      changed: [],
+      hasValidSession: true,
+    });
 
     vsCodeStub.window.withProgress.callsFake(async (_options, task) => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/jupyter/workbench-instance-manager.ts
+++ b/src/jupyter/workbench-instance-manager.ts
@@ -82,7 +82,7 @@ export class WorkbenchInstanceManager {
    *
    * @param projectId - The ID of the GCP project.
    */
-  setProjectId(projectId: string) {
+  setProjectId(projectId?: string) {
     this.projectId = projectId;
   }
 
@@ -142,6 +142,7 @@ export class WorkbenchInstanceManager {
       this.vs.window.showInformationMessage(
         `No active Workbench instances found in project: ${projectId}.`,
       );
+      this.projectId = undefined;
     }
 
     return this.cachedServers;

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -87,6 +87,7 @@ export interface VsCodeStub {
     // eslint-disable-next-line @/max-len
     registerAuthenticationProvider: typeof vscode.authentication.registerAuthenticationProvider;
     getSession: typeof vscode.authentication.getSession;
+    onDidChangeSessions: typeof vscode.authentication.onDidChangeSessions;
   };
 }
 
@@ -155,6 +156,7 @@ export function newVsCodeStub(): VsCodeStub {
           fakeAuthentication,
         ),
       getSession: fakeAuthentication.getSession.bind(fakeAuthentication),
+      onDidChangeSessions: sinon.stub().returns({ dispose: sinon.stub() }),
     },
   };
 }


### PR DESCRIPTION
#### Changes
- Updated auth events and subscribed `provider` to avoid sending API calls while not authenticated
- Added Sign-out notification

#### Current behavior (_before kernel picker reverts back! See below_.)
- Sign-out via UI
- Notification is shown and kernel disconnects, kernel picker gets reset
- If attempting to run the cell, the popup will open to select a kernel. Alternatively user can select a kernel first via a dedicated picker.

#### Note
Apparently, there is no way to force Jupyter extension to clear list of recent kernels/sessions. Re-creating Jupyter collection does not help. Colab Consumer bypasses it by using custom WebSocket Proxy and a dedicated connection manager - https://github.com/googlecolab/colab-vscode/blob/main/src/jupyter/contents/sessions.ts. That relies on the API which is unrecommended and may be changed w/o notice. 
That said, roughly after ~5s after sign-out Jupyter updates kernel picker with the previous kernel. From that moment attempts to run the cell will result in an error being shown. Because Jupyter extension will call `resolveJupyterServer`, which will throw due to being unauthenticated. I haven't found a way to control what is being shown in the error. Neither I wanted to show custom popup message, bc that method might be called multiple times throughout the lifecycle. Alternative would be to kick off the auth flow from that point and always attempt to reconnect user to the previous Kernel. That is also suboptimal, because we are forcing them to re-connect.

![Screen Recording 2026-03-20 at 17 41 24](https://github.com/user-attachments/assets/e22eaad2-1e95-4f59-a970-c9443d611b62)


At the end user is alway able to select a new kernel and authenticate, but prior reconnecting results in an error (if user waited long enough >5s after sign-out).

Any ideas are welcome!



