### PR TITLE
Enable matching by project ID in quick pick

### DIFF
--- a/src/test/helpers/quick-input.ts
+++ b/src/test/helpers/quick-input.ts
@@ -31,6 +31,7 @@ export type QuickPickStub = sinon.SinonStubbedInstance<
     | 'placeholder'
     | 'items'
     | 'activeItems'
+    | 'matchOnDetail'
     | 'selectedItems'
     | 'buttons'
     | 'onDidTriggerButton'
@@ -71,6 +72,7 @@ export function buildQuickPickStub(
     totalSteps: undefined,
     ignoreFocusOut: false,
     placeholder: undefined,
+    matchOnDetail: false,
     items: [],
     activeItems: [],
     selectedItems: [],

--- a/src/workbench/commands.ts
+++ b/src/workbench/commands.ts
@@ -53,6 +53,9 @@ export async function selectProjectCommand(
         ignoreFocusOut: true,
         placeholder: 'Select a Google Cloud Project',
         items: initialItems,
+        onDidCreate: (quickPick) => {
+          quickPick.matchOnDetail = true;
+        },
         onDidChangeValue: (value, quickPick) => {
           if (searchTimeout) {
             clearTimeout(searchTimeout);

--- a/src/workbench/commands.unit.test.ts
+++ b/src/workbench/commands.unit.test.ts
@@ -164,6 +164,24 @@ describe('selectProjectCommand', () => {
       expect(result).to.deep.equal({ label: 'Instance 1', id: 'i-1' });
     });
 
+    it('enables matching by detail for project selection', async () => {
+      const commandPromise = selectProjectCommand(
+        vsCodeStub,
+        resourceManagerStub,
+        instanceManagerStub,
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(quickPicks.length).to.equal(1);
+      const qp = quickPicks[0];
+      expect(qp.matchOnDetail).to.be.true;
+
+      // Cancel the flow to resolve the promise
+      qp.onDidHide.getCall(0).args[0]();
+      await commandPromise;
+    });
+
     it('opens external URL when project has no instances', async () => {
       instanceManagerStub.getWorkbenchServers.resolves([]);
 


### PR DESCRIPTION
#### Summary
Whenever a user searches by ID our project client returns correct list of projects. However, at quick pick stage VS Code filters out results that do not contain a certain substring inside the label. This PR also enables matching by details, which is mapped to project ID.

#### Note:
There are still discrepancies between how our search works and how the search in GCP project selector works. Mainly, they are related to handling special chars, like `-`. If you search for smth like `q-` API will return a bunch of results, but most of them will not contain this exact substring, forcing VS Code quick pick to filter them out on UI. Currently, user can easily bypass it by typing more characters or simply choosing a different search string. Turns out there is no way to stop VS Code from filtering those results out in quick pick. We probably can try forcing the API to interpret those chars as raw symbols by proper escaping, but I haven't found a quick way to do that. Hence, leaving that for a follow-up.
