### PR TITLE
test: dismiss initial modal windows during e2e test setup

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -47,6 +47,10 @@ describe('Workbench Extension', function () {
     // Wait for VS Code UI to settle before running tests.
     workbench = new Workbench();
     driver = workbench.getDriver();
+
+    // Dismiss any modal window that appears at start.
+    await driver.sleep(ELEMENT_WAIT_MS);
+    await driver.actions().sendKeys(Key.ESCAPE).perform();
     await driver.sleep(ELEMENT_WAIT_MS);
   });
 


### PR DESCRIPTION
Closing VScode modal after 116.0 update