### PR TITLE
fix: Changing extension name from 'Workbench' to 'Workbench Notebooks'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ TODO A clear and concise description of what the bug is.
 ## Environment
 
 - VS Code version: TODO
-- Workbench extension version: TODO
+- Workbench Notebooks extension version: TODO
 - Jupyter extension version: TODO
 - OS (Linux | Mac | Windows): TODO
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ TODO: Optionally add any other context about the problem here.
 
 ## Logs
 
-Logs from `Workbench` in the `Output` panel (`View` > `Output`, change the drop-down the upper-right of the `Output` panel to `Workbench`).
+Logs from `Workbench Notebooks` in the `Output` panel (`View` > `Output`, change the drop-down the upper-right of the `Output` panel to `Workbench Notebooks`).
 
 ```txt
 TODO

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Vertex AI Workbench VS Code Extension
+# Workbench Notebooks VS Code Extension
 
-[Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction) instances are Jupyter notebook-based development environments for the entire data science workflow. You can interact with Vertex AI and other Google Cloud services from within a Vertex AI Workbench instance's Jupyter notebook. Built atop
+[Workbench Notebooks](https://cloud.google.com/vertex-ai/docs/workbench/introduction) instances are Jupyter notebook-based development environments for the entire data science workflow. You can interact with other Google Cloud services from within a Workbench instance's Jupyter notebook. Built atop
 the [Jupyter
 extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter),
 this extension exposes Workbench Jupyter servers directly in VS Code!

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ this extension exposes Workbench Jupyter servers directly in VS Code!
 
 1. Install [VS Code](https://code.visualstudio.com).
 1. Install the Workbench extension from either the [Visual Studio
-   Marketplace](https://marketplace.visualstudio.com/items?itemName=googlecloudtools.workbench)
-   or [Open VSX](https://open-vsx.org/extension/googlecloudtools/workbench).
+   Marketplace](https://marketplace.visualstudio.com/items?itemName=googlecloudtools.workbench-notebooks)
+   or [Open VSX](https://open-vsx.org/extension/googlecloudtools/workbench-notebooks).
 1. Install the [Jupyter
    extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) if not already installed.
 1. Open or create a notebook file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "workbench",
+  "name": "workbench-notebooks",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "workbench",
+      "name": "workbench-notebooks",
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/notebooks": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "workbench",
+  "name": "workbench-notebooks",
   "publisher": "googlecloudtools",
-  "displayName": "Workbench",
+  "displayName": "Workbench Notebooks",
   "description": "Connect notebooks to Vertex AI Workbench instances.",
   "icon": "icon.png",
   "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
       }
     ],
     "configuration": {
-      "title": "Workbench",
+      "title": "Workbench Notebooks",
       "properties": {
-        "workbench.logging.level": {
+        "workbench-notebooks.logging.level": {
           "type": "string",
           "default": "info",
           "enum": [
@@ -58,7 +58,7 @@
             "info",
             "debug"
           ],
-          "description": "Controls the verbosity of logs. These can be found in the 'Workbench' output channel."
+          "description": "Controls the verbosity of logs. These can be found in the 'Workbench Notebooks' output channel."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "workbench-notebooks",
   "publisher": "googlecloudtools",
   "displayName": "Workbench Notebooks",
-  "description": "Connect notebooks to Vertex AI Workbench instances.",
+  "description": "Connect notebooks to Workbench instances.",
   "icon": "icon.png",
   "version": "0.1.0",
   "pricing": "Free",

--- a/src/common/logger.unit.test.ts
+++ b/src/common/logger.unit.test.ts
@@ -72,9 +72,9 @@ describe('Logger', () => {
   });
 
   describe('initializeLogger', () => {
-    it('creates output channel "Workbench"', () => {
+    it('creates output channel "Workbench Notebooks"', () => {
       loggerDisposable = initializeLogger(vscode, mockContext);
-      sinon.assert.calledWith(createOutputChannelStub, 'Workbench');
+      sinon.assert.calledWith(createOutputChannelStub, 'Workbench Notebooks');
     });
 
     it('logs environment info on initialization', () => {
@@ -89,7 +89,7 @@ describe('Logger', () => {
       );
       sinon.assert.calledWith(
         outputChannelMock.appendLine,
-        sinon.match(/\[INFO\].*Workbench extension version: 1.2.3/),
+        sinon.match(/\[INFO\].*Workbench Notebooks extension version: 1.2.3/),
       );
     });
 

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -101,13 +101,13 @@ export function initializeLogger(
 
   level = getConfiguredLogLevel(vs);
   const configListener = vs.workspace.onDidChangeConfiguration((e) => {
-    if (e.affectsConfiguration('workbench.logging')) {
+    if (e.affectsConfiguration('workbench-notebooks.logging')) {
       level = getConfiguredLogLevel(vs);
     }
   });
 
   // Create the output channel once.
-  const outputChannel = vs.window.createOutputChannel('Workbench');
+  const outputChannel = vs.window.createOutputChannel('Workbench Notebooks');
   loggers.push(new OutputChannelLogger(outputChannel));
 
   if (context.extensionMode === vs.ExtensionMode.Development) {
@@ -119,7 +119,7 @@ export function initializeLogger(
   log.info(`Visual Studio Code: ${vs.version}`);
   log.info(`Remote: ${vs.env.remoteName ?? 'local'}`);
   log.info(
-    `Workbench extension version: ${(context.extension.packageJSON as { version: string }).version}`,
+    `Workbench Notebooks extension version: ${(context.extension.packageJSON as { version: string }).version}`,
   );
 
   return {
@@ -194,7 +194,7 @@ const LOG_CONFIG_TO_LEVEL: Record<
 
 function getConfiguredLogLevel(vs: typeof vscode): LogLevel {
   const configLevel = vs.workspace
-    .getConfiguration('workbench.logging')
+    .getConfiguration('workbench-notebooks.logging')
     .get<Lowercase<keyof typeof LogLevel>>('level', 'info');
 
   return LOG_CONFIG_TO_LEVEL[configLevel] || LogLevel.Info;

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -101,7 +101,7 @@ export function initializeLogger(
 
   level = getConfiguredLogLevel(vs);
   const configListener = vs.workspace.onDidChangeConfiguration((e) => {
-    if (e.affectsConfiguration('workbench-notebooks.logging')) {
+    if (e.affectsConfiguration('workbench.logging')) {
       level = getConfiguredLogLevel(vs);
     }
   });

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -194,7 +194,7 @@ const LOG_CONFIG_TO_LEVEL: Record<
 
 function getConfiguredLogLevel(vs: typeof vscode): LogLevel {
   const configLevel = vs.workspace
-    .getConfiguration('workbench-notebooks.logging')
+    .getConfiguration('workbench.logging')
     .get<Lowercase<keyof typeof LogLevel>>('level', 'info');
 
   return LOG_CONFIG_TO_LEVEL[configLevel] || LogLevel.Info;

--- a/src/config/package-info.ts
+++ b/src/config/package-info.ts
@@ -28,9 +28,9 @@ export function getPackageInfo(ext: Extension<unknown>): PackageInfo {
 }
 
 export function getExtension(): Extension<unknown> {
-  const ext = extensions.getExtension('googlecloudtools.workbench');
+  const ext = extensions.getExtension('googlecloudtools.workbench-notebooks');
   if (!ext) {
-    throw new Error('Extension googlecloudtools.workbench not found');
+    throw new Error('Extension googlecloudtools.workbench-notebooks not found');
   }
   return ext;
 }

--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -25,7 +25,7 @@ const ELEMENT_WAIT_MS = 60 * 1000;
 const CELL_EXECUTION_WAIT_MS = 30 * 1000;
 const AUTH_WAIT_MS = 1000;
 
-describe('Workbench Extension', function () {
+describe('Workbench Notebooks Extension', function () {
   dotenv.config();
 
   let driver: WebDriver;
@@ -79,13 +79,13 @@ describe('Workbench Extension', function () {
       }
 
       await selectQuickPickItem({
-        item: 'Workbench',
+        item: 'Workbench Notebooks',
         quickPick: 'Select a Jupyter Server',
       });
 
       await pushDialogButton({
         button: 'Allow',
-        dialog: "The extension 'Workbench' wants to sign in using Google.",
+        dialog: "The extension 'Workbench Notebooks' wants to sign in using Google.",
       });
 
       // Begin the sign-in process by copying the OAuth URL to the clipboard and

--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -85,7 +85,8 @@ describe('Workbench Notebooks Extension', function () {
 
       await pushDialogButton({
         button: 'Allow',
-        dialog: "The extension 'Workbench Notebooks' wants to sign in using Google.",
+        dialog:
+          "The extension 'Workbench Notebooks' wants to sign in using Google.",
       });
 
       // Begin the sign-in process by copying the OAuth URL to the clipboard and

--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -79,7 +79,7 @@ describe('Workbench Notebooks Extension', function () {
       }
 
       await selectQuickPickItem({
-        item: 'Workbench Notebooks',
+        item: 'Workbench',
         quickPick: 'Select a Jupyter Server',
       });
 

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -9,12 +9,12 @@ import vscode from 'vscode';
 
 describe('Extension', () => {
   it('should be present', () => {
-    assert.ok(vscode.extensions.getExtension('googlecloudtools.workbench'));
+    assert.ok(vscode.extensions.getExtension('googlecloudtools.workbench-notebooks'));
   });
 
   it('should activate', async () => {
     const extension = vscode.extensions.getExtension(
-      'googlecloudtools.workbench',
+      'googlecloudtools.workbench-notebooks',
     );
 
     await extension?.activate();

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -9,7 +9,9 @@ import vscode from 'vscode';
 
 describe('Extension', () => {
   it('should be present', () => {
-    assert.ok(vscode.extensions.getExtension('googlecloudtools.workbench-notebooks'));
+    assert.ok(
+      vscode.extensions.getExtension('googlecloudtools.workbench-notebooks'),
+    );
   });
 
   it('should activate', async () => {

--- a/src/workbench/constants.ts
+++ b/src/workbench/constants.ts
@@ -27,8 +27,8 @@ export interface RegisteredCommand extends Command {
  * server.
  */
 export const WORKBENCH_COMMAND: JupyterServerCommand = {
-  label: 'Workbench Notebooks',
-  description: 'Connect to Vertex AI Workbench',
+  label: 'Workbench',
+  description: 'Connect to Workbench Instances',
 };
 
 export const NO_ACTIVE_INSTANCE_LABEL =

--- a/src/workbench/constants.ts
+++ b/src/workbench/constants.ts
@@ -27,7 +27,7 @@ export interface RegisteredCommand extends Command {
  * server.
  */
 export const WORKBENCH_COMMAND: JupyterServerCommand = {
-  label: 'Workbench',
+  label: 'Workbench Notebooks',
   description: 'Connect to Vertex AI Workbench',
 };
 


### PR DESCRIPTION
Since name for VScode extension should be globally unique by themself regardless from publisher field, the PR introduces changes of the name from 'Workbench' to 'Workbench notebooks'

Previous name was caused a publish conflict with another VScode extension
