### PR TITLE
ci: add contents: read to the PR pre-merge checks workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   call_build_and_test:
     name: Build and Test


### PR DESCRIPTION
Single-job caller that delegates to `build-test.yml` (a `workflow_call` reusable) with `secrets: inherit`. The reusable runs npm install + lint + test + build — all read-side operations on the default `GITHUB_TOKEN`. Declaring `contents: read` at the caller documents the minimum scope and removes reliance on the repo default; intersection with the reusable is safe (the reusable does not declare its own permissions block today).

YAML parses cleanly.